### PR TITLE
Add gpt-4-128k support

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,11 +235,11 @@ Returns a decoded string from a list of tokens.
 
 #### `Chunker._get_token_limit()`
 
-Returns the token limit for each gpt-3.5 and gpt-4 model, current as of August 13, 2023.
+Returns the token limit for each gpt-3.5 and gpt-4 model, current as of November 7, 2023.
 
 #### `Chunker._get_price_per_token()`
 
-Returns the price per token in cents for each gpt-3.5 and gpt-4 model, current as of August 13, 2023.
+Returns the price per token in cents for each gpt-3.5 and gpt-4 model, current as of November 7, 2023.
 
 #### `Chunker._get_complete_token_count(text)`
 
@@ -261,7 +261,7 @@ If the completion fails, ChunkGPT will retry up to 3 times, with a delay of 1 se
 
 ## Examples
 
-The [Github repo](https://www.github.com/dimays/chunkgpt) for ChunkGPT inclues long sample .txt files to test out in the `examples/` directory. Each file, when added to the existing system and user message templates, exceeds the token limit for all available OpenAI GPT models (as of August 13, 2023).
+The [Github repo](https://www.github.com/dimays/chunkgpt) for ChunkGPT inclues long sample .txt files to test out in the `examples/` directory. Each file, when added to the existing system and user message templates, exceeds the token limit for all available OpenAI GPT models (as of November 7, 2023).
 
 You can test out the utility of this library against large texts by using these sample texts and employing any GPT models or Chunker object attributes you wish to experiment with.
 

--- a/src/chunkgpt.egg-info/PKG-INFO
+++ b/src/chunkgpt.egg-info/PKG-INFO
@@ -249,11 +249,11 @@ Returns a decoded string from a list of tokens.
 
 #### `Chunker._get_token_limit()`
 
-Returns the token limit for each gpt-3.5 and gpt-4 model, current as of August 13, 2023.
+Returns the token limit for each gpt-3.5 and gpt-4 model, current as of November 7, 2023.
 
 #### `Chunker._get_price_per_token()`
 
-Returns the price per token in cents for each gpt-3.5 and gpt-4 model, current as of August 13, 2023.
+Returns the price per token in cents for each gpt-3.5 and gpt-4 model, current as of November 7, 2023.
 
 #### `Chunker._get_complete_token_count(text)`
 
@@ -275,7 +275,7 @@ If the completion fails, ChunkGPT will retry up to 3 times, with a delay of 1 se
 
 ## Examples
 
-The [Github repo](https://www.github.com/dimays/chunkgpt) for ChunkGPT inclues long sample .txt files to test out in the `examples/` directory. Each file, when added to the existing system and user message templates, exceeds the token limit for all available OpenAI GPT models (as of August 13, 2023).
+The [Github repo](https://www.github.com/dimays/chunkgpt) for ChunkGPT inclues long sample .txt files to test out in the `examples/` directory. Each file, when added to the existing system and user message templates, exceeds the token limit for all available OpenAI GPT models (as of November 7, 2023).
 
 You can test out the utility of this library against large texts by using these sample texts and employing any GPT models or Chunker object attributes you wish to experiment with.
 

--- a/src/chunkgpt/chunkgpt.py
+++ b/src/chunkgpt/chunkgpt.py
@@ -262,9 +262,11 @@ class Chunker:
     
     def _get_token_limit(self):
         """Returns the token limit for each gpt-3.5 and gpt-4 model,
-        current as of August 13, 2023."""
+        current as of November 07, 2023."""
         if self.model.startswith('gpt-3.5-turbo-16k'):
             token_limit = 16384
+        elif self.model.startswith('gpt-4-1106'):
+            token_limit = 128000
         elif self.model.startswith('gpt-4-32k'):
             token_limit = 32768
         elif self.model.startswith('gpt-4'):
@@ -275,9 +277,11 @@ class Chunker:
 
     def _get_price_per_token(self):
         """Returns the price per token in cents for each gpt-3.5 and
-        gpt-4 model, current as of August 13, 2023."""
+        gpt-4 model, current as of November 07, 2023."""
         if self.model.startswith('gpt-3.5-turbo-16k'):
             price = 0.0003
+        if self.model.startswith('gpt-4-1106'):
+            price = 0.01
         elif self.model.startswith('gpt-4-32k'):
             price = 0.006
         elif self.model.startswith('gpt-4'):


### PR DESCRIPTION
Per OAI's [announcement](https://openai.com/blog/new-models-and-developer-products-announced-at-devday), GPT-4 128k is here. This adds token support, else you'll hit `token_limit` errors when trying to use the model.